### PR TITLE
add: DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM (allow using widevine drm)

### DIFF
--- a/Scripts/Common/Deblob.sh
+++ b/Scripts/Common/Deblob.sh
@@ -181,26 +181,28 @@ echo "Deblobbing...";
 	fi;
 
 	#DRM
-	blobs=$blobs"|liboemcrypto.so|libtzdrmgenprov.so";
-	blobs=$blobs"|libpvr.so|librmp.so|libsi.so|libSSEPKCS11.so";
-	blobs=$blobs"|libdrmctaplugin.so|libdrmmtkplugin.so|libdrmmtkwhitelist.so|libmockdrmcryptoplugin.so";
-	blobs=$blobs"|libOMXVideoDecoder.*Secure.so"; #Decoding
-	blobs=$blobs"|htc_drmprov.*|gpsample.mbn|gptauuid.xml"; #HTC
-	blobs=$blobs"|if.bin"; #Intel PAVP backend
-	blobs=$blobs"|liblgdrm.so"; #LG
-	#blobs=$blobs"|libtpa_core.so|libdataencrypt_tpa.so|libpkip.so"; #OMAP SMC
-	blobs=$blobs"|vendor.oneplus.hardware.drmkey.*|bin[/]hw[/]vendor.oneplus.hardware.hdcpkey.*|etc[/]init[/]vendor.oneplus.hardware.hdcpkey.*"; #OnePlus
-	#blobs=$blobs"|vendor.oneplus.hardware.hdcpkey.*.so"; #XXX: Breaks radio, linked by libril-qc-hal-qmi.so
-	manifests=$manifests"|OneplusHdcpKey";
-	blobs=$blobs"|smc_pa.ift|drmserver.samsung"; #Samsung
-	blobs=$blobs"|provision_device";
-	#blobs=$blobs"|libasfparser.so|libsavsff.so"; #Parsers
-	makes=$makes"|android.hardware.drm.*|liboemcrypto";
-	manifests=$manifests"|android.hardware.drm";
-	#makes=$makes"|libdrmframework.*"; #necessary to compile
-	#makes=$makes"|mediadrmserver|com.android.mediadrm.signer.*|drmserver"; #Works but causes long boot times
-	#sepolicy=$sepolicy" drmserver.te mediadrmserver.te";
-	sepolicy=$sepolicy" hal_drm_default.te hal_drm.te hal_drm_widevine.te";
+	if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then
+		blobs=$blobs"|liboemcrypto.so|libtzdrmgenprov.so";
+		blobs=$blobs"|libpvr.so|librmp.so|libsi.so|libSSEPKCS11.so";
+		blobs=$blobs"|libdrmctaplugin.so|libdrmmtkplugin.so|libdrmmtkwhitelist.so|libmockdrmcryptoplugin.so";
+		blobs=$blobs"|libOMXVideoDecoder.*Secure.so"; #Decoding
+		blobs=$blobs"|htc_drmprov.*|gpsample.mbn|gptauuid.xml"; #HTC
+		blobs=$blobs"|if.bin"; #Intel PAVP backend
+		blobs=$blobs"|liblgdrm.so"; #LG
+		#blobs=$blobs"|libtpa_core.so|libdataencrypt_tpa.so|libpkip.so"; #OMAP SMC
+		blobs=$blobs"|vendor.oneplus.hardware.drmkey.*|bin[/]hw[/]vendor.oneplus.hardware.hdcpkey.*|etc[/]init[/]vendor.oneplus.hardware.hdcpkey.*"; #OnePlus
+		#blobs=$blobs"|vendor.oneplus.hardware.hdcpkey.*.so"; #XXX: Breaks radio, linked by libril-qc-hal-qmi.so
+		manifests=$manifests"|OneplusHdcpKey";
+		blobs=$blobs"|smc_pa.ift|drmserver.samsung"; #Samsung
+		blobs=$blobs"|provision_device";
+		#blobs=$blobs"|libasfparser.so|libsavsff.so"; #Parsers
+		makes=$makes"|android.hardware.drm.*|liboemcrypto";
+		manifests=$manifests"|android.hardware.drm";
+		#makes=$makes"|libdrmframework.*"; #necessary to compile
+		#makes=$makes"|mediadrmserver|com.android.mediadrm.signer.*|drmserver"; #Works but causes long boot times
+		#sepolicy=$sepolicy" drmserver.te mediadrmserver.te";
+		sepolicy=$sepolicy" hal_drm_default.te hal_drm.te hal_drm_widevine.te";
+	fi;
 
 	#eMBMS [Qualcomm]
 	blobs=$blobs"|embms.apk";
@@ -648,14 +650,15 @@ echo "Deblobbing...";
 	manifests=$manifests"|wfdhdcp|wifidisplayhdcphal|WifiDisplay";
 
 	#Widevine (DRM) [Google]
-	blobs=$blobs"|libdrmwvmplugin.so|libmarlincdmplugin.so|libwvdrmengine.so|libwvdrm_L1.so|libwvdrm_L3.so|libwvhidl.so|libwvm.so|libWVphoneAPI.so|libWVStreamControlAPI_L1.so|libWVStreamControlAPI_L3.so|libdrmmtkutil.so|libsepdrm.*.so|libvtswidevine32.so|libvtswidevine64.so|android.hardware.drm.*widevine.*";
-	blobs=$blobs"|test-wvdrmplugin|oemwvtest";
-	blobs=$blobs"|com.google.widevine.software.drm.jar";
-	blobs=$blobs"|com.google.widevine.software.drm.xml";
-	#blobs=$blobs"|smc_pa_wvdrm.ift"; breaks maguro/toro* boot
-	blobs=$blobs"|tzwidevine.*|tzwvcpybuf.*|widevine.*";
-	makes=$makes"|libshim_wvm|move_widevine_data.sh|android.hardware.drm.*widevine.*";
-
+    if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then
+		blobs=$blobs"|libdrmwvmplugin.so|libmarlincdmplugin.so|libwvdrmengine.so|libwvdrm_L1.so|libwvdrm_L3.so|libwvhidl.so|libwvm.so|libWVphoneAPI.so|libWVStreamControlAPI_L1.so|libWVStreamControlAPI_L3.so|libdrmmtkutil.so|libsepdrm.*.so|libvtswidevine32.so|libvtswidevine64.so|android.hardware.drm.*widevine.*";
+		blobs=$blobs"|test-wvdrmplugin|oemwvtest";
+		blobs=$blobs"|com.google.widevine.software.drm.jar";
+		blobs=$blobs"|com.google.widevine.software.drm.xml";
+		#blobs=$blobs"|smc_pa_wvdrm.ift"; breaks maguro/toro* boot
+		blobs=$blobs"|tzwidevine.*|tzwvcpybuf.*|widevine.*";
+		makes=$makes"|libshim_wvm|move_widevine_data.sh|android.hardware.drm.*widevine.*";
+    fi;
 	#WiPower (Wireless Charging) [Qualcomm]
 	blobs=$blobs"|libwbc_jni.so|wbc_hal.default.so";
 	blobs=$blobs"|a4wpservice.apk|com.quicinc.wbcserviceapp.apk";
@@ -691,8 +694,10 @@ deblobDevice() {
 		if [ "$DOS_DEBLOBBER_REMOVE_IMS" = true ]; then sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(IMS_SYMLINKS)//' Android.mk; fi; #Remove IMS firmware
 		sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(PLAYREADY_SYMLINKS)//' Android.mk; #Remove Microsoft Playready firmware
 		sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(SECUREUI_SYMLINKS)//' Android.mk; #Remove SecureUI blobs
-		sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(WIDEVINE_SYMLINKS)//' Android.mk; #Remove Google Widevine firmware
-		sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(WV_SYMLINKS)//' Android.mk; #Remove Google Widevine firmware
+  		if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then
+			sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(WIDEVINE_SYMLINKS)//' Android.mk; #Remove Google Widevine firmware
+			sed -i '/ALL_DEFAULT_INSTALLED_MODULES/s/$(WV_SYMLINKS)//' Android.mk; #Remove Google Widevine firmware
+  		fi;
 	fi;
 	if [ -f BoardConfig.mk ]; then
 		if [ -z "$replaceTime" ]; then
@@ -737,7 +742,7 @@ deblobDevice() {
 	fi;
 
 	sed -i '/loc.nlp_name/d' *.prop *.mk &>/dev/null || true; #Disable QC Location Provider
-	sed -i 's/drm.service.enabled=true/drm.service.enabled=false/' *.prop *.mk &>/dev/null || true;
+  	if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then sed -i 's/drm.service.enabled=true/drm.service.enabled=false/' *.prop *.mk &>/dev/null || true; fi;
 	if [ "$DOS_DEBLOBBER_REMOVE_APTX" = true ]; then sed -i 's/bt.enableAptXHD=true/bt.enableAptXHD=false/' *.prop *.mk &>/dev/null || true; fi; #Disable aptX
 	if [ "$DOS_DEBLOBBER_REMOVE_CNE" = true ]; then sed -i 's/cne.feature=./cne.feature=0/' *.prop *.mk &>/dev/null || true; fi; #Disable CNE
 	if [ "$DOS_DEBLOBBER_REMOVE_DPM" = true ]; then
@@ -751,7 +756,7 @@ deblobDevice() {
 	sed -i 's/wfd.enable=1/wfd.enable=0/' *.prop *.mk &>/dev/null || true; #Disable Wi-Fi display
 	sed -i '/vendor.camera.extensions/d' *.prop *.mk &>/dev/null || true; #Disable camera extensions
 	if [ -f system.prop ]; then
-		if ! grep -q "drm.service.enabled=false" system.prop; then echo "drm.service.enabled=false" >> system.prop; fi; #Disable DRM server
+		if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then if ! grep -q "drm.service.enabled=false" system.prop; then echo "drm.service.enabled=false" >> system.prop; fi; fi; #Disable DRM server
 		if [ "$DOS_DEBLOBBER_REMOVE_GRAPHICS" = true ]; then
 			echo "sys.ui.hw=disable" >> system.prop;
 			#echo "graphics.gles20.disable_on_bootanim=1" >> system.prop;
@@ -895,8 +900,10 @@ deblobVendorBp() {
 	sed -i -E "s/srcs.*("$blobs").*/srcs: \[\"proprietary\/vendor\/lib\/libtime_genoff.so\"\], enabled: false,/g" "$bpfile";
 	#TODO make this work for more then these two blobs
 	#Credit: https://stackoverflow.com/a/26053127
-	sed -i ':a;N;s/\n/&/3;Ta;/manifest_android.hardware.drm@1.*-service.widevine.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
-	sed -i ':a;N;s/\n/&/3;Ta;/manifest_android.hardware.drm-service.widevine.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
+  	if [ "$DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM" == "true" ]; then
+		sed -i ':a;N;s/\n/&/3;Ta;/manifest_android.hardware.drm@1.*-service.widevine.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
+		sed -i ':a;N;s/\n/&/3;Ta;/manifest_android.hardware.drm-service.widevine.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
+ 	fi;
 	sed -i ':a;N;s/\n/&/3;Ta;/manifest_vendor.xiaomi.hardware.mlipay.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
 	sed -i ':a;N;s/\n/&/3;Ta;/vendor.qti.hardware.radio.atcmdfwd@1.0.xml/!{P;D};:b;N;s/\n/&/8;Tb;d' "$bpfile";
 	if [ "$DOS_DEBLOBBER_REMOVE_FACE" = true ]; then


### PR DESCRIPTION
With this change it is possible to enable or disable the removal of WIDEVINE DRM by the flag "DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM".

Some streaming apps (e.g. DAZN) need widevine drm. I tried to find a minimal set of needed blobs. Maybe this could be further reduced. In addition one could think about the default behaviour and either add 
`DOS_DEBLOBBER_REMOVE_WIDEVINE_DRM = true `
to the divested vars or switch the logic for the if statements within Deblob.sh. Any opinion?